### PR TITLE
Fix/queue

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -109,4 +109,36 @@ class Connection
         $stmt = $this->executeQuery($sql, $params);
         return $stmt->rowCount();
     }
+
+    /**
+     * Create a new query builder instance
+     */
+    public function qb(): QueryBuilder
+    {
+        return new QueryBuilder($this);
+    }
+
+    /**
+     * Begin a database transaction
+     */
+    public function beginTransaction(): bool
+    {
+        return $this->pdo()->beginTransaction();
+    }
+
+    /**
+     * Commit the current transaction
+     */
+    public function commit(): bool
+    {
+        return $this->pdo()->commit();
+    }
+
+    /**
+     * Roll back the current transaction
+     */
+    public function rollback(): bool
+    {
+        return $this->pdo()->rollBack();
+    }
 }

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -24,6 +24,8 @@ class QueryBuilder
 
     private array $joins = [];
 
+    private bool $forUpdate = false;
+
     public function __construct(private Connection $connection)
     {
     }
@@ -39,6 +41,7 @@ class QueryBuilder
         $this->offsetCount = null;
         $this->joins = [];
         $this->bindings = [];
+        $this->forUpdate = false;
         return $this;
     }
 
@@ -335,6 +338,12 @@ class QueryBuilder
     public function offset(int $count): self
     {
         $this->offsetCount = max(0, $count);
+        return $this;
+    }
+
+    public function lockForUpdate(): self
+    {
+        $this->forUpdate = true;
         return $this;
     }
 
@@ -708,6 +717,10 @@ class QueryBuilder
 
         if ($this->offsetCount !== null) {
             $sql .= ' OFFSET ' . $this->offsetCount;
+        }
+
+        if ($this->forUpdate) {
+            $sql .= ' FOR UPDATE';
         }
 
         return $sql;

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -719,7 +719,7 @@ class QueryBuilder
             $sql .= ' OFFSET ' . $this->offsetCount;
         }
 
-        if ($this->forUpdate) {
+        if ($this->forUpdate && $this->supportsForUpdate()) {
             $sql .= ' FOR UPDATE';
         }
 
@@ -855,6 +855,17 @@ class QueryBuilder
     private function camelToSnake(string $input): string
     {
         return strtolower((string) preg_replace('/([a-z])([A-Z])/', '$1_$2', $input));
+    }
+
+    /**
+     * Check if the current database driver supports FOR UPDATE
+     */
+    private function supportsForUpdate(): bool
+    {
+        $driverName = $this->connection->getDriver()->getName();
+        
+        // SQLite doesn't support FOR UPDATE, MySQL and PostgreSQL do
+        return in_array($driverName, ['mysql', 'postgresql', 'pgsql'], true);
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for transaction management and row-level locking to the database layer, making it easier and safer to work with concurrent data modifications. The main changes include new transaction methods in the `Connection` class and the ability to use `FOR UPDATE` locks in the `QueryBuilder`.

**Transaction Management Enhancements:**

* Added `beginTransaction`, `commit`, and `rollback` methods to the `Connection` class, allowing you to start, commit, and roll back transactions directly.

**Query Builder Improvements:**

* Introduced a new `qb` method in the `Connection` class to create a `QueryBuilder` instance more conveniently.
* Added a `lockForUpdate` method and a `forUpdate` flag to `QueryBuilder`, enabling the use of row-level locks in select queries. [[1]](diffhunk://#diff-ebb1085e1718aba388c6af56be4efcb22ca61286743082c970d9b62300bcf2c5R27-R28) [[2]](diffhunk://#diff-ebb1085e1718aba388c6af56be4efcb22ca61286743082c970d9b62300bcf2c5R344-R349)
* Ensured that the `forUpdate` flag is reset when switching tables in the query builder to avoid unintended locking.

**Database Compatibility Handling:**

* Implemented a `supportsForUpdate` check in `QueryBuilder` to ensure `FOR UPDATE` is only used with supported database drivers (MySQL and PostgreSQL, not SQLite).
* Updated the SQL generation logic to append `FOR UPDATE` to select statements only when supported and requested.