### PR TITLE
Hardening p0

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -18,7 +18,7 @@ return [
     | to any of the stores defined in the "stores" array below.
     |
     */
-    'default' => $_ENV['CACHE_DRIVER'] ?? 'file',
+    'default' => 'file',
 
     /*
     |--------------------------------------------------------------------------
@@ -38,16 +38,16 @@ return [
 
         'file' => [
             'driver' => 'file',
-            'path' => $_ENV['CACHE_PATH'] ?? null, // Uses storage/cache by default
+            'path' => null, // Uses storage/cache by default
             'permissions' => 0755,
         ],
 
         'redis' => [
             'driver' => 'redis',
-            'host' => $_ENV['REDIS_HOST'] ?? '127.0.0.1',
-            'password' => $_ENV['REDIS_PASSWORD'] ?? null,
-            'port' => $_ENV['REDIS_PORT'] ?? 6379,
-            'database' => $_ENV['REDIS_CACHE_DB'] ?? 1,
+            'host' => '127.0.0.1',
+            'password' => null,
+            'port' => 6379,
+            'database' => 1,
             'timeout' => 5.0,
             'retry_interval' => 100,
             'read_timeout' => 60.0,
@@ -64,7 +64,7 @@ return [
     | with other applications using the same cache backend.
     |
     */
-    'prefix' => $_ENV['CACHE_PREFIX'] ?? 'baseapi_cache',
+    'prefix' => 'baseapi_cache',
 
     /*
     |--------------------------------------------------------------------------
@@ -75,7 +75,7 @@ return [
     | explicitly specified. Set to null for no expiration by default.
     |
     */
-    'default_ttl' => (int)($_ENV['CACHE_DEFAULT_TTL'] ?? 3600), // 1 hour
+    'default_ttl' => 3600, // 1 hour
 
     /*
     |--------------------------------------------------------------------------
@@ -98,8 +98,8 @@ return [
     |
     */
     'response_cache' => [
-        'enabled' => $_ENV['CACHE_RESPONSES'] ?? false,
-        'default_ttl' => (int)($_ENV['CACHE_RESPONSE_TTL'] ?? 600), // 10 minutes
+        'enabled' => false,
+        'default_ttl' => 600, // 10 minutes
         'prefix' => 'response',
         'vary_headers' => ['Accept', 'Accept-Encoding', 'Authorization'],
         'ignore_query_params' => ['_t', 'timestamp', 'cache_bust'],

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -38,8 +38,9 @@ return [
     ],
 
     'database' => [
+        'driver' => 'mysql',
         'host' => '127.0.0.1',
-        'port' => 7878,
+        'port' => 3306,
         'name' => 'baseapi',
         'user' => 'root',
         'password' => '',
@@ -95,11 +96,11 @@ return [
     ],
 
     'openai' => [
-        'api_key' => $_ENV['OPENAI_API_KEY'] ?? '',
-        'default_model' => $_ENV['OPENAI_DEFAULT_MODEL'] ?? 'gpt-4.1-mini',
-        'temperature' => (float)($_ENV['OPENAI_TEMPERATURE'] ?? 1.0),
-        'max_output_tokens' => (int)($_ENV['OPENAI_MAX_TOKENS'] ?? 1000),
-        'timeout' => (int)($_ENV['OPENAI_TIMEOUT'] ?? 30),
-        'max_retries' => (int)($_ENV['OPENAI_MAX_RETRIES'] ?? 3),
+        'api_key' => '',
+        'default_model' => 'gpt-4.1-mini',
+        'temperature' => 1.0,
+        'max_output_tokens' => 1000,
+        'timeout' => 30,
+        'max_retries' => 3,
     ],
 ];

--- a/docs/src/pages/Security/ApiTokenAuth.tsx
+++ b/docs/src/pages/Security/ApiTokenAuth.tsx
@@ -167,11 +167,12 @@ curl -X DELETE http://localhost:8080/api-tokens/token-id \\
             </List>
 
             <Typography variant="h3" gutterBottom sx={{ mt: 3, mb: 2 }}>
-                Enhanced Request Object
+                Accessing Authenticated User Data
             </Typography>
 
             <Typography paragraph>
-                Both authentication methods populate the request with consistent user data:
+                Both authentication methods populate the request with consistent user data.
+                Always use <code>$this-&gt;request-&gt;user</code> to access the authenticated user:
             </Typography>
 
             <CodeBlock language="php" code={`<?php
@@ -185,11 +186,14 @@ class ExampleController extends Controller
 {
     public function get(): JsonResponse
     {
-        // User data is available regardless of auth method
+        // ✅ CORRECT: Access user via request object
         $user = $this->request->user;
         
-        // You can check which authentication method was used
+        // ✅ CORRECT: Check which authentication method was used
         $authMethod = $this->request->authMethod; // "session" or "api_token"
+        
+        // ✅ CORRECT: Access session data if needed
+        $sessionData = $this->request->session;
         
         return JsonResponse::ok([
             'user' => $user,
@@ -198,6 +202,23 @@ class ExampleController extends Controller
         ]);
     }
 }`} />
+
+            <Alert severity="error" sx={{ my: 2 }}>
+                <strong>Never access $_SESSION directly!</strong> Always use <code>$this-&gt;request-&gt;user</code> for 
+                authenticated user data and <code>$this-&gt;request-&gt;session</code> for session variables. 
+                Direct $_SESSION access bypasses the framework's authentication abstraction and breaks compatibility 
+                with both session-based and token-based authentication.
+            </Alert>
+
+            <CodeBlock language="php" code={`<?php
+
+// ❌ WRONG: Direct $_SESSION access
+$userId = $_SESSION['user_id'] ?? null;
+$_SESSION['user_id'] = $user->id;
+
+// ✅ CORRECT: Use request object
+$user = $this->request->user; // Works for both session and token auth
+$this->request->session['user_id'] = $user->id; // If you need to modify session`} />
 
             <Divider sx={{ my: 4 }} />
 

--- a/docs/src/pages/Security/Overview.tsx
+++ b/docs/src/pages/Security/Overview.tsx
@@ -105,6 +105,10 @@ DB_PASSWORD=secure_random_password
                 Authentication & Authorization
             </Typography>
 
+            <Typography paragraph>
+                BaseAPI provides multiple authentication methods that all populate the request object consistently:
+            </Typography>
+
             <CodeBlock language="php" code={`<?php
 
 // Protect routes with authentication middleware
@@ -119,7 +123,41 @@ $router->delete('/users/{id}', [
     AuthMiddleware::class,
     RateLimitMiddleware::class => ['limit' => '5/1m'],
     UserController::class
+]);
+
+// Combined authentication (supports both session and API tokens)
+$router->get('/profile', [
+    App\\Middleware\\CombinedAuthMiddleware::class,
+    ProfileController::class
 ]);`} />
+
+            <Typography variant="h3" gutterBottom sx={{ mt: 3, mb: 2 }}>
+                Accessing Authenticated Users
+            </Typography>
+
+            <Alert severity="info" sx={{ my: 2 }}>
+                Always use <code>$this-&gt;request-&gt;user</code> to access authenticated user data. 
+                Never access <code>$_SESSION</code> directly as this bypasses the authentication 
+                abstraction and breaks compatibility with API token authentication.
+            </Alert>
+
+            <CodeBlock language="php" code={`<?php
+
+class SecureController extends Controller
+{
+    public function get(): JsonResponse
+    {
+        // ✅ CORRECT: Access authenticated user
+        $user = $this->request->user;
+        
+        // User is available regardless of auth method (session or token)
+        return JsonResponse::ok([
+            'id' => $user['id'],
+            'name' => $user['name'],
+            'email' => $user['email']
+        ]);
+    }
+}`} />
 
             <Typography variant="h2" gutterBottom sx={{ mt: 4 }}>
                 Rate Limiting
@@ -144,6 +182,7 @@ $router->post('/api/data', [
                 • Use HTTPS in production
                 • Keep dependencies updated
                 • Implement proper authentication
+                • Never access $_SESSION directly - use $this-&gt;request-&gt;user
                 • Apply rate limiting to public endpoints
                 • Use environment variables for secrets
                 • Enable security headers
@@ -154,6 +193,7 @@ $router->post('/api/data', [
                 <strong>Security Best Practices:</strong>
                 <br />• Never trust user input - always validate
                 <br />• Use BaseAPI's built-in validation and middleware
+                <br />• Never access $_SESSION directly - use $this-&gt;request-&gt;user and $this-&gt;request-&gt;session
                 <br />• Keep your environment variables secure
                 <br />• Apply rate limiting to prevent abuse
                 <br />• Use HTTPS and security headers in production

--- a/scripts/check-no-env.sh
+++ b/scripts/check-no-env.sh
@@ -32,3 +32,4 @@ fi
 echo "✅ No direct \$_ENV usage found in src/"
 exit 0
 
+

--- a/scripts/check-no-env.sh
+++ b/scripts/check-no-env.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# CI check script to prevent direct $_ENV usage in framework code
+# Usage: ./scripts/check-no-env.sh
+
+set -e
+
+echo "🔍 Checking for direct \$_ENV usage in src/..."
+
+# Search for $_ENV in src/ directory, excluding specific allowed files
+# App.php is allowed because it passes $_ENV to Config constructor
+if grep -r '\$_ENV' src/ \
+    --exclude-dir=vendor \
+    --exclude="App.php" \
+    | grep -v "// \$_ENV" \
+    | grep -v "* \$_ENV"; then
+    
+    echo ""
+    echo "❌ ERROR: Direct \$_ENV usage detected in src/"
+    echo ""
+    echo "Please use Config::get('dot.path', default) instead of \$_ENV['KEY']"
+    echo ""
+    echo "Examples:"
+    echo "  ❌ \$_ENV['APP_DEBUG']"
+    echo "  ✅ App::config('app.debug', false)"
+    echo ""
+    echo "  ❌ \$_ENV['DB_HOST']"
+    echo "  ✅ App::config('database.host', '127.0.0.1')"
+    echo ""
+    exit 1
+fi
+
+echo "✅ No direct \$_ENV usage found in src/"
+exit 0
+

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -211,10 +211,10 @@ class CacheManager implements CacheInterface
     protected function createRedisStore(array $config): RedisStore
     {
         $redisConfig = [
-            'host' => $config['host'] ?? $_ENV['REDIS_HOST'] ?? '127.0.0.1',
-            'port' => $config['port'] ?? $_ENV['REDIS_PORT'] ?? 6379,
-            'password' => $config['password'] ?? $_ENV['REDIS_PASSWORD'] ?? null,
-            'database' => $config['database'] ?? $_ENV['REDIS_CACHE_DB'] ?? 0,
+            'host' => $config['host'] ?? '127.0.0.1',
+            'port' => $config['port'] ?? 6379,
+            'password' => $config['password'] ?? null,
+            'database' => $config['database'] ?? 0,
             'timeout' => $config['timeout'] ?? 5.0,
             'retry_interval' => $config['retry_interval'] ?? 100,
             'read_timeout' => $config['read_timeout'] ?? 60.0,

--- a/src/Console/Commands/QueueWorkCommand.php
+++ b/src/Console/Commands/QueueWorkCommand.php
@@ -72,7 +72,7 @@ class QueueWorkCommand implements Command
         int $memoryLimit
     ): int {
         // Generate screen session name
-        $appName = App::config('app.name') ?? $_ENV['APP_NAME'] ?? 'baseapi';
+        $appName = App::config('app.name', 'baseapi');
         $screenName = strtolower((string) preg_replace('/[^a-zA-Z0-9-_]/', '-', (string) $appName)) . '-queue';
         
         // Check if screen is available

--- a/src/Console/Commands/ServeCommand.php
+++ b/src/Console/Commands/ServeCommand.php
@@ -33,8 +33,8 @@ class ServeCommand implements Command
         // Check for --screen flag
         $useScreen = in_array('--screen', $args);
         
-        $host = App::config('app.host') ?? $_ENV['APP_HOST'] ?? 'localhost';
-        $port = App::config('app.port') ?? $_ENV['APP_PORT'] ?? '7879';
+        $host = App::config('app.host', 'localhost');
+        $port = App::config('app.port', '7879');
         
         $address = sprintf('%s:%s', $host, $port);
         
@@ -54,7 +54,7 @@ class ServeCommand implements Command
         
         if ($useScreen) {
             // Run in detached screen session
-            $appName = App::config('app.name') ?? $_ENV['APP_NAME'] ?? 'baseapi';
+            $appName = App::config('app.name', 'baseapi');
             $screenName = strtolower((string) preg_replace('/[^a-zA-Z0-9-_]/', '-', (string) $appName)) . '-api';
             
             // Check if screen is available

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -27,7 +27,7 @@ class Connection
     public function getDriver(): DatabaseDriverInterface
     {
         if (!$this->driver instanceof DatabaseDriverInterface) {
-            $driverName = $_ENV['DB_DRIVER'] ?? 'mysql';
+            $driverName = App::config('database.driver', 'mysql');
             $this->driver = DatabaseDriverFactory::create($driverName);
         }
 
@@ -38,14 +38,16 @@ class Connection
     {
         $driver = $this->getDriver();
 
+        $defaultPort = $driver->getName() === 'mysql' ? 3306 : null;
+        
         $config = [
-            'host' => $_ENV['DB_HOST'] ?? '127.0.0.1',
-            'port' => $_ENV['DB_PORT'] ?? ($driver->getName() === 'mysql' ? '3306' : null),
-            'database' => $_ENV['DB_NAME'] ?? ($_ENV['DB_DATABASE'] ?? 'baseapi'),
-            'username' => $_ENV['DB_USER'] ?? ($_ENV['DB_USERNAME'] ?? 'root'),
-            'password' => $_ENV['DB_PASSWORD'] ?? ($_ENV['DB_PASS'] ?? ''),
-            'charset' => $_ENV['DB_CHARSET'] ?? 'utf8mb4',
-            'persistent' => ($_ENV['DB_PERSISTENT'] ?? 'false') === 'true',
+            'host' => App::config('database.host', '127.0.0.1'),
+            'port' => App::config('database.port', $defaultPort),
+            'database' => App::config('database.name', 'baseapi'),
+            'username' => App::config('database.user', 'root'),
+            'password' => App::config('database.password', ''),
+            'charset' => App::config('database.charset', 'utf8mb4'),
+            'persistent' => App::config('database.persistent', false),
         ];
 
         $this->pdo = $driver->createConnection($config);

--- a/src/Database/Migrations/ModelScanner.php
+++ b/src/Database/Migrations/ModelScanner.php
@@ -456,8 +456,8 @@ class ModelScanner
                 }
             }
 
-            if (isset($override['null'])) {
-                $column->nullable = $override['null'];
+            if (isset($override['nullable'])) {
+                $column->nullable = $override['nullable'];
             }
 
             if (isset($override['default'])) {

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -19,7 +19,7 @@ class RateLimitMiddleware implements Middleware, OptionedMiddleware
 
     public function __construct()
     {
-        $dir = $_ENV['RATE_LIMIT_DIR'] ?? 'storage/ratelimits';
+        $dir = App::config('rate_limit.dir', 'storage/ratelimits');
 
         // Convert to absolute path if relative
         if (!str_starts_with((string) $dir, '/')) {
@@ -135,7 +135,7 @@ class RateLimitMiddleware implements Middleware, OptionedMiddleware
             return 'user:' . $_SESSION['user_id'];
         }
 
-        $trustProxy = ($_ENV['APP_TRUST_PROXY'] ?? 'false') === 'true';
+        $trustProxy = App::config('rate_limit.trust_proxy', false);
         $ip = ClientIp::from($request, $trustProxy);
 
         return 'ip:' . $ip;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -31,28 +31,14 @@ class Logger
             return;
         }
 
-        // Get logging configuration from environment or config
-        // Use $_ENV directly first to avoid circular dependencies
-        $this->channel = $_ENV['LOG_CHANNEL'] ?? 'file';
-        $this->minLevel = strtolower($_ENV['LOG_LEVEL'] ?? 'debug');
-
-        // If channel not in env, try config (but only after App is fully booted)
-        if (!isset($_ENV['LOG_CHANNEL']) && class_exists('\BaseApi\App')) {
-            $this->channel = App::config('logging.default', 'file');
-        }
-
-        if (!isset($_ENV['LOG_LEVEL']) && class_exists('\BaseApi\App')) {
-            $this->minLevel = strtolower((string) App::config('logging.level', 'debug'));
-        }
+        // Get logging configuration from config
+        // Config::get() safely handles env variables internally
+        $this->channel = App::config('logging.default', 'file');
+        $this->minLevel = strtolower((string) App::config('logging.level', 'debug'));
 
         // For file driver, set up the log path in application's storage directory
         if ($this->channel === 'file') {
-            $relativePath = $_ENV['LOG_FILE'] ?? 'storage/logs/baseapi.log';
-
-            // Try config if env not set
-            if (!isset($_ENV['LOG_FILE']) && class_exists('\BaseApi\App')) {
-                $relativePath = App::config('logging.path', 'storage/logs/baseapi.log');
-            }
+            $relativePath = App::config('logging.path', 'storage/logs/baseapi.log');
 
             // Resolve the absolute path
             if (str_starts_with((string) $relativePath, 'storage/')) {

--- a/src/OpenApi/Builders/IRBuilder.php
+++ b/src/OpenApi/Builders/IRBuilder.php
@@ -54,10 +54,10 @@ class IRBuilder
         }
 
         return new ApiIR(
-            title: $_ENV['APP_NAME'] ?? 'BaseApi',
+            title: App::config('app.name', 'BaseApi'),
             version: '1.0.0',
             description: 'Generated API documentation',
-            baseUrl: $_ENV['APP_URL'] ?? null,
+            baseUrl: App::config('app.url'),
             operations: $operations,
             models: $modelIRs,
             routes: $routeIRs,

--- a/src/OpenApi/OpenApiGenerator.php
+++ b/src/OpenApi/OpenApiGenerator.php
@@ -446,8 +446,9 @@ class OpenApiGenerator
         ];
 
         // Add server info if available
-        if (isset($_ENV['APP_URL'])) {
-            $spec['servers'] = [['url' => $_ENV['APP_URL']]];
+        $appUrl = App::config('app.url');
+        if ($appUrl) {
+            $spec['servers'] = [['url' => $appUrl]];
         }
 
         // Generate paths

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -11,7 +11,6 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use BaseApi\Database\Connection;
 use BaseApi\Database\Drivers\DatabaseDriverInterface;
-use BaseApi\App;
 
 class ConnectionTest extends TestCase
 {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -7,9 +7,11 @@ use PDOStatement;
 use Override;
 use ReflectionClass;
 use PDOException;
+use Exception;
 use PHPUnit\Framework\TestCase;
 use BaseApi\Database\Connection;
 use BaseApi\Database\Drivers\DatabaseDriverInterface;
+use BaseApi\App;
 
 class ConnectionTest extends TestCase
 {
@@ -317,41 +319,138 @@ class ConnectionTest extends TestCase
         $connectMethod->invoke($this->connection);
     }
 
-    public function testConnectUsesEnvironmentVariables(): void
+    public function testConnectUsesConfigValues(): void
     {
-        $_ENV['DB_HOST'] = 'localhost';
-        $_ENV['DB_PORT'] = '5432';
-        $_ENV['DB_DATABASE'] = 'test_db';
-        $_ENV['DB_USERNAME'] = 'test_user';
-        $_ENV['DB_PASSWORD'] = 'test_pass';
-        $_ENV['DB_CHARSET'] = 'utf8';
-        $_ENV['DB_PERSISTENT'] = 'true';
+        // Note: This test validates that Connection uses App::config() 
+        // After refactoring to use Config::get() instead of direct $_ENV access,
+        // we test that the config system works correctly.
+        
+        // Check if real App is already loaded (from other tests in suite)
+        $appExists = class_exists('BaseApi\App', false);
+        $isRealApp = $appExists && method_exists('BaseApi\App', 'boot');
+        
+        if ($isRealApp) {
+            // Real App is loaded - test with default config values
+            // This happens when running full test suite where other tests load App
+            $expectedConfig = [
+                'host' => '127.0.0.1',
+                'port' => 3306,
+                'database' => 'baseapi',
+                'username' => 'root',
+                'password' => '',
+                'charset' => 'utf8mb4',
+                'persistent' => false,
+            ];
+        } else {
+            // Mock App - can test custom config values
+            $_ENV['database.host'] = 'localhost';
+            $_ENV['database.port'] = '5432';
+            $_ENV['database.name'] = 'test_db';
+            $_ENV['database.user'] = 'test_user';
+            $_ENV['database.password'] = 'test_pass';
+            $_ENV['database.charset'] = 'utf8';
+            $_ENV['database.persistent'] = 'true';
+            
+            // Only create mock if it doesn't exist
+            if (!class_exists('BaseApi\App', false)) {
+                $this->createMockAppClass();
+            }
+            
+            $expectedConfig = [
+                'host' => 'localhost',
+                'port' => '5432',
+                'database' => 'test_db',
+                'username' => 'test_user',
+                'password' => 'test_pass',
+                'charset' => 'utf8',
+                'persistent' => true,
+            ];
+        }
 
-        $expectedConfig = [
-            'host' => 'localhost',
-            'port' => '5432',
-            'database' => 'test_db',
-            'username' => 'test_user',
-            'password' => 'test_pass',
-            'charset' => 'utf8',
-            'persistent' => true,
-        ];
+        // Create a fresh Connection instance for this test
+        $connection = new Connection();
 
         $this->mockDriver->expects($this->once())
             ->method('createConnection')
             ->with($expectedConfig)
             ->willReturn($this->mockPdo);
 
-        $this->mockDriver->method('getName')->willReturn('postgresql');
+        $this->mockDriver->method('getName')->willReturn($isRealApp ? 'mysql' : 'postgresql');
 
         // Use reflection to inject mock driver and call connect
-        $reflection = new ReflectionClass($this->connection);
+        $reflection = new ReflectionClass($connection);
         $driverProperty = $reflection->getProperty('driver');
         $driverProperty->setAccessible(true);
-        $driverProperty->setValue($this->connection, $this->mockDriver);
+        $driverProperty->setValue($connection, $this->mockDriver);
 
         $connectMethod = $reflection->getMethod('connect');
         $connectMethod->setAccessible(true);
-        $connectMethod->invoke($this->connection);
+        $connectMethod->invoke($connection);
+
+        // Cleanup
+        if (!$isRealApp) {
+            unset($_ENV['database.host'], $_ENV['database.port'], $_ENV['database.name'], 
+                  $_ENV['database.user'], $_ENV['database.password'], $_ENV['database.charset'], 
+                  $_ENV['database.persistent']);
+        }
+    }
+
+    private function createMockAppClass(): void
+    {
+        $mockClassContent = <<<'PHP'
+<?php
+namespace BaseApi {
+    class App {
+        public static function config(string $key = '', mixed $default = null): mixed
+        {
+            // Return values based on key, checking $_ENV first
+            if ($key !== '' && isset($_ENV[$key])) {
+                $value = $_ENV[$key];
+                // Handle boolean conversion
+                if ($key === 'database.persistent' && is_string($value)) {
+                    return $value === 'true';
+                }
+                return $value;
+            }
+            
+            return match($key) {
+                'database.driver' => 'mysql',
+                'database.host' => '127.0.0.1',
+                'database.port' => 3306,
+                'database.name' => 'baseapi',
+                'database.user' => 'root',
+                'database.password' => '',
+                'database.charset' => 'utf8mb4',
+                'database.persistent' => false,
+                default => $default
+            };
+        }
+    }
+}
+PHP;
+
+        // Fix temp file leak: tempnam() creates a file, rename it to avoid leak
+        $tempFile = tempnam(sys_get_temp_dir(), 'mock_app_');
+        if ($tempFile === false) {
+            throw new Exception('Failed to create temporary file');
+        }
+
+        $phpTempFile = $tempFile . '.php';
+        if (!rename($tempFile, $phpTempFile)) {
+            @unlink($tempFile); // Clean up original if rename fails
+            throw new Exception('Failed to rename temporary file');
+        }
+        
+        if (file_put_contents($phpTempFile, $mockClassContent) === false) {
+            @unlink($phpTempFile);
+            throw new Exception('Failed to create mock App class file');
+        }
+
+        try {
+            require_once $phpTempFile;
+        } finally {
+            // Always clean up the temporary file
+            @unlink($phpTempFile);
+        }
     }
 }


### PR DESCRIPTION
This pull request refactors configuration handling across the codebase to eliminate direct usage of `$_ENV` in favor of the centralized `App::config()` method. This makes configuration more consistent, secure, and easier to manage, and ensures compatibility with different environments. It also updates documentation to emphasize best practices for accessing authenticated user and session data, and adds a CI script to enforce the new configuration standard.

**Configuration Refactoring**

* All configuration values in `config/cache.php` and `config/defaults.php` now use hardcoded defaults instead of reading from `$_ENV`, removing environment variable lookups from config files. [[1]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL21-R21) [[2]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL41-R50) [[3]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL67-R67) [[4]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL78-R78) [[5]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL101-R102) [[6]](diffhunk://#diff-bcc1e50439cf4f7a7e858a7ce8c473ee898c85d4a7549386ed47993bc9886d89R41-R43) [[7]](diffhunk://#diff-bcc1e50439cf4f7a7e858a7ce8c473ee898c85d4a7549386ed47993bc9886d89L98-R104)
* All usages of `$_ENV` in core classes (`src/Database/Connection.php`, `src/Cache/CacheManager.php`, `src/Console/Commands/QueueWorkCommand.php`, `src/Console/Commands/ServeCommand.php`, `src/Logger.php`, `src/OpenApi/Builders/IRBuilder.php`, `src/OpenApi/OpenApiGenerator.php`, `src/Http/Middleware/RateLimitMiddleware.php`) are replaced with `App::config()`, ensuring consistent configuration access. [[1]](diffhunk://#diff-668f990447328e105dabad862baeca00199f612bcc8fc028a13c9562bb274179L30-R30) [[2]](diffhunk://#diff-668f990447328e105dabad862baeca00199f612bcc8fc028a13c9562bb274179R41-R50) [[3]](diffhunk://#diff-9e2c72cfd4f12f83c095fbbfc47e632bd76064556cf6d815f15cd0427d8f4ce5L214-R217) [[4]](diffhunk://#diff-285e9d421b3f9b53da357f17e3a9ba9b759c220a0ca4d61e2c75c94b7b1df8b2L75-R75) [[5]](diffhunk://#diff-e8080025290b29192f26e3ac2772a2d521c4ef0398383847e1fe9a5f66f409a1L36-R37) [[6]](diffhunk://#diff-e8080025290b29192f26e3ac2772a2d521c4ef0398383847e1fe9a5f66f409a1L57-R57) [[7]](diffhunk://#diff-d6a00c7572381de9ee69f8f73e7fa7e41073a19467332fb28017c9b1a69bcbdbL34-L55) [[8]](diffhunk://#diff-68329db47b766134dd21ffdd2da0ce01423fbde4a104a56c634ae33ee1923571L57-R60) [[9]](diffhunk://#diff-562baa6df5323dcc5c106e5f7eaa6960ff10eac02061863b58cdacf74b6f806bL449-R451) [[10]](diffhunk://#diff-6e09dba788b742e0010c694b0dfe4b7d336f423710f54eea18c751be0e86806fL22-R22) [[11]](diffhunk://#diff-6e09dba788b742e0010c694b0dfe4b7d336f423710f54eea18c751be0e86806fL138-R138)

**Documentation Updates**

* Security documentation is updated to strongly recommend accessing authenticated user and session data via `$this->request->user` and `$this->request->session`, never directly via `$_SESSION`, to maintain compatibility with both session and token authentication. [[1]](diffhunk://#diff-04b0b16e108db4693ed8947ab66c6bc1b3812e53e12bc67ce7cf56dd22d4338aL170-R175) [[2]](diffhunk://#diff-04b0b16e108db4693ed8947ab66c6bc1b3812e53e12bc67ce7cf56dd22d4338aL188-R197) [[3]](diffhunk://#diff-04b0b16e108db4693ed8947ab66c6bc1b3812e53e12bc67ce7cf56dd22d4338aR206-R222) [[4]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR108-R111) [[5]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR126-R161) [[6]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR185) [[7]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR196)

**Tooling and Enforcement**

* Adds a CI script `scripts/check-no-env.sh` to fail builds if direct `$_ENV` usage is detected in framework code, enforcing the new configuration standard.

**Minor Fixes**

* Fixes a migration override bug by correcting the array key from `'null'` to `'nullable'` in `ModelScanner.php`.

---

**References:**  
[[1]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL21-R21) [[2]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL41-R50) [[3]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL67-R67) [[4]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL78-R78) [[5]](diffhunk://#diff-1add210cb1f30d8f14eb2d3934d64fbfd8dec0a7823dc746c6136fc8e0c3da2fL101-R102) [[6]](diffhunk://#diff-bcc1e50439cf4f7a7e858a7ce8c473ee898c85d4a7549386ed47993bc9886d89R41-R43) [[7]](diffhunk://#diff-bcc1e50439cf4f7a7e858a7ce8c473ee898c85d4a7549386ed47993bc9886d89L98-R104) [[8]](diffhunk://#diff-668f990447328e105dabad862baeca00199f612bcc8fc028a13c9562bb274179L30-R30) [[9]](diffhunk://#diff-668f990447328e105dabad862baeca00199f612bcc8fc028a13c9562bb274179R41-R50) [[10]](diffhunk://#diff-9e2c72cfd4f12f83c095fbbfc47e632bd76064556cf6d815f15cd0427d8f4ce5L214-R217) [[11]](diffhunk://#diff-285e9d421b3f9b53da357f17e3a9ba9b759c220a0ca4d61e2c75c94b7b1df8b2L75-R75) [[12]](diffhunk://#diff-e8080025290b29192f26e3ac2772a2d521c4ef0398383847e1fe9a5f66f409a1L36-R37) [[13]](diffhunk://#diff-e8080025290b29192f26e3ac2772a2d521c4ef0398383847e1fe9a5f66f409a1L57-R57) [[14]](diffhunk://#diff-d6a00c7572381de9ee69f8f73e7fa7e41073a19467332fb28017c9b1a69bcbdbL34-L55) [[15]](diffhunk://#diff-68329db47b766134dd21ffdd2da0ce01423fbde4a104a56c634ae33ee1923571L57-R60) [[16]](diffhunk://#diff-562baa6df5323dcc5c106e5f7eaa6960ff10eac02061863b58cdacf74b6f806bL449-R451) [[17]](diffhunk://#diff-6e09dba788b742e0010c694b0dfe4b7d336f423710f54eea18c751be0e86806fL22-R22) [[18]](diffhunk://#diff-6e09dba788b742e0010c694b0dfe4b7d336f423710f54eea18c751be0e86806fL138-R138) [[19]](diffhunk://#diff-04b0b16e108db4693ed8947ab66c6bc1b3812e53e12bc67ce7cf56dd22d4338aL170-R175) [[20]](diffhunk://#diff-04b0b16e108db4693ed8947ab66c6bc1b3812e53e12bc67ce7cf56dd22d4338aL188-R197) [[21]](diffhunk://#diff-04b0b16e108db4693ed8947ab66c6bc1b3812e53e12bc67ce7cf56dd22d4338aR206-R222) [[22]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR108-R111) [[23]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR126-R161) [[24]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR185) [[25]](diffhunk://#diff-07704109d6f26cf6c8ff0848f598b4587190902a71c1c5a00944ed01f9c2a3eeR196) [[26]](diffhunk://#diff-b8e70b0d61678df543c065bb3c2afc9427e0da00cfd86291e81fb184bb93a7b8R1-R35) [[27]](diffhunk://#diff-b7b8cff75e85aa15009bb16335c81cf8dad931b95b6dac69dc92c8565d1f1a5dL459-R460)